### PR TITLE
null: false制約を解除

### DIFF
--- a/db/migrate/20210721221340_change_column_to_allow_null.rb
+++ b/db/migrate/20210721221340_change_column_to_allow_null.rb
@@ -1,0 +1,6 @@
+class ChangeColumnToAllowNull < ActiveRecord::Migration[6.0]
+  def up
+    change_column :instabots, :user_name, :string, null: true
+    change_column :instabots, :password, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_11_001854) do
+ActiveRecord::Schema.define(version: 2021_07_21_221340) do
 
   create_table "instabots", force: :cascade do |t|
-    t.string "user_name", null: false
-    t.string "password", null: false
+    t.string "user_name"
+    t.string "password"
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 解説
- instabotsテーブルのuser_name、password カラムの
null: false -> null:true へ変更。※upメソッドを定義。