### PR TITLE
フォロー・アンフォロー両on時のエラー表示

### DIFF
--- a/app/controllers/concerns/instabot_action.rb
+++ b/app/controllers/concerns/instabot_action.rb
@@ -37,6 +37,8 @@ module InstabotAction
       end
     end
     
+
+    
     def good_hashtag(key_word, number)
       if @rcd.good == true
         username = session[:instabot]["user_name"]
@@ -80,7 +82,9 @@ module InstabotAction
       end
     end
 
-    def auto_follow(key_word)
+
+
+    def auto_follow(key_word, hash_rcds, hash_rcd)
       if @rcd.follow == true && @rcd.unfollow == false
         username = session[:instabot]["user_name"]
         password = session[:instabot]["password"]
@@ -109,18 +113,21 @@ module InstabotAction
         rescue
           puts "このタグは既にフォロー済みです"
         end
-      elsif @rcd.follow == true && @rcd.unfollow == true
+      elsif hash_rcd == hash_rcds[0] && @rcd.follow == true && @rcd.unfollow == true
         flash[:error] = "'登録済みの自動アンフォロー'をoffにしてから再度操作して下さい。"
         @rcd.update_attribute(:follow, !@rcd.follow)
         respond_to do |format|
           format.js { render ajax_redirect_to(root_path) }
         end
       else
+        @rcd.update_attribute(:user_id, !@rcd.follow)
         puts "フォローは'#{@rcd.follow}'です"
       end
     end
 
-    def auto_unfollow(key_word)
+
+
+    def auto_unfollow(key_word, hash_rcds, hash_rcd)
       if @rcd.unfollow == true && @rcd.follow == false
         username = session[:instabot]["user_name"]
         password = session[:instabot]["password"]
@@ -149,16 +156,20 @@ module InstabotAction
         rescue
           puts "このタグは既にフォロー解除済みです"
         end
-      elsif @rcd.unfollow == true && @rcd.follow == true
+      elsif hash_rcd == hash_rcds[0] && @rcd.unfollow == true && @rcd.follow == true
         flash[:error] = "'自動フォロー'をoffにしてから再度操作して下さい。"
         @rcd.update_attribute(:unfollow, !@rcd.unfollow)
         respond_to do |format|
           format.js { render ajax_redirect_to(root_path) }
+          puts "アンフォローは'#{@rcd.unfollow}'です"
         end
+      elsif hash_rcd != hash_rcds[0] && @rcd.unfollow == true && @rcd.follow == true
+        @rcd.update_attribute(:unfollow, @rcd.unfollow)
       else
         puts "アンフォローは'#{@rcd.unfollow}'です"
       end
     end
   end
 end
+
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   def index
     @auto = Instabot.new
     @hashtag = Hashtag.new
+    # @key_word = Hashtag.
     #新規登録の場合（データベースにデータがまだ無い場合）
     if Instabot.exists?(user_id: current_user.id)
        @instabot_rcd = Instabot.find_by(user_id: current_user.id)

--- a/app/javascript/packs/submit.js
+++ b/app/javascript/packs/submit.js
@@ -9,7 +9,7 @@ $(() => {
       datatype: "html",
     }).done(function(data) {
       console.log("ajax送信成功");
-      console.log($(".auto").serializeArray());
+      // console.log($(".auto").serializeArray()[1]);
     }).fail(function(data) {
       console.log("失敗");
     })
@@ -33,16 +33,3 @@ $(() => {
 });
 
 
-// XMLHttpRequest ajax
-// const インスタンス名 = new XMLHttpRequest();
-
-// インスタンス名.open( 'POST', 送信先 );
-// インスタンス名.setRequestHeader( 'content-type', 'application/x-www-form-urlencoded;charset=UTF-8' );
-// インスタンス名.send( 'パラメータ=値' );
-
-// インスタンス名.onreadystatechange = function() {
-//   if( インスタンス名.readyState === 4 && インスタンス名.status === 200 ) {
-//     //エラーを出さずに通信が完了した時の処理。例↓
-//     console.log( インスタンス名.responseText );
-//   }
-// }


### PR DESCRIPTION
## 解説
- フォロー・アンフォロー両方onにした時に表示されるべきエラーが表示されなかった
件、ループ処理をかけたデータの2番目がすぐに読み込まれた為に、redirect_to(エラー表示はこれでページ遷移した
後に表示される)が一瞬で処理され、あたかもエラー表示が出てないかの様な結果になっていた。
それを1回目が読み込まれた後にbreakをかけてループ処理から抜ける事で解決した。